### PR TITLE
feat: add release changelog workflow (forum + HTML)

### DIFF
--- a/.github/workflows/generate-release-changelog.yml
+++ b/.github/workflows/generate-release-changelog.yml
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
+name: Generate changelog on release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  changelog_generate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check actor permission
+        uses: skjnldsv/check-actor-permission@69e92a3c4711150929bca9fcf34448c5bf5526e7 # v3.0
+        with:
+          require: write
+
+      - name: Checkout github_helper
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          repository: nextcloud/github_helper
+          path: github_helper
+
+      - name: Checkout server
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          path: server
+          fetch-depth: 0
+
+      - name: Get previous tag
+        shell: bash
+        run: |
+          cd server
+          # Print all tags
+          git log --decorate --oneline | egrep 'tag: ' | sed -r 's/^.+tag: ([^,\)]+)[,\)].+$/\1/g'
+          # Get the current tag
+          TAGS=$(git log --decorate --oneline | egrep 'tag: ' | sed -r 's/^.+tag: ([^,\)]+)[,\)].+$/\1/g')
+          CURRENT_TAG=$(echo "$TAGS" | head -n 1)
+
+          # If current tag is the first beta, we use the previous major RC1
+          if echo "$CURRENT_TAG" | grep -q 'beta1'; then
+            MAJOR=$(echo "$CURRENT_TAG" | sed -E 's/^v([0-9]+).*/\1/')
+            PREV=$((MAJOR - 1))
+            PREVIOUS_TAG="v${PREV}.0.0rc1"
+          # Get the previous tag - filter pre-releases only if current tag is stable
+          elif echo "$CURRENT_TAG" | grep -q 'rc\|beta\|alpha'; then
+            # Current tag is pre-release, don't filter
+            PREVIOUS_TAG=$(echo "$TAGS" | sed -n '2p')
+          else
+            # Current tag is stable, filter out pre-releases
+            PREVIOUS_TAG=$(echo "$TAGS" | grep -v 'rc\|beta\|alpha' | sed -n '2p')
+          fi
+
+          echo "CURRENT_TAG=$CURRENT_TAG" >> $GITHUB_ENV
+          echo "PREVIOUS_TAG=$PREVIOUS_TAG" >> $GITHUB_ENV
+
+      # Since this action only runs on nextcloud-releases, ignoring is okay
+      - name: Verify current tag # zizmor: ignore[template-injection]
+        run: |
+         if [ "${{ github.ref_name }}" != "${{ env.CURRENT_TAG }}" ]; then
+           echo "Current tag does not match the release tag. Exiting."
+           exit 1
+         fi
+
+      - name: Set up php 8.2
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+        timeout-minutes: 5
+        with:
+          php-version: 8.2
+          coverage: none
+          ini-file: development
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set credentials
+        run: |
+          echo '{"username": "github-actions"}' > github_helper/credentials.json
+
+      - name: Install github_helper dependencies
+        run: |
+          cd github_helper/changelog
+          composer install
+
+      # Since this action only runs on nextcloud-releases, ignoring is okay
+      - name: Generate forum changelog between ${{ env.PREVIOUS_TAG }} and ${{ github.ref_name }} # zizmor: ignore[template-injection]
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd github_helper/changelog
+          php index.php generate:changelog --no-bots --format=forum server ${{ env.PREVIOUS_TAG }} ${{ github.ref_name }} > changelog.md
+
+      # Since this action only runs on nextcloud-releases, ignoring is okay
+      - name: Generate HTML changelog between ${{ env.PREVIOUS_TAG }} and ${{ github.ref_name }} # zizmor: ignore[template-injection]
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd github_helper/changelog
+          php index.php generate:changelog --no-bots --format=html server ${{ env.PREVIOUS_TAG }} ${{ github.ref_name }} > "${{ github.ref_name }}.html"
+
+      # Since this action only runs on nextcloud-releases, ignoring is okay
+      - name: Set changelog to release # zizmor: ignore[template-injection]
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+         cd server
+         gh release edit ${{ github.ref_name }} --notes-file "../github_helper/changelog/changelog.md" --title "${{ github.ref_name }}"
+
+      # Since this action only runs on nextcloud-releases, ignoring is okay
+      - name: Attach HTML changelog to release # zizmor: ignore[template-injection]
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+         cd server
+         gh release upload ${{ github.ref_name }} "../github_helper/changelog/${{ github.ref_name }}.html" --clobber

--- a/.github/workflows/generate-release-changelog.yml
+++ b/.github/workflows/generate-release-changelog.yml
@@ -6,6 +6,11 @@ name: Generate changelog on release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to (re)generate changelog for (e.g., v33.0.4)'
+        required: true
 
 permissions:
   contents: write
@@ -13,6 +18,9 @@ permissions:
 jobs:
   changelog_generate:
     runs-on: ubuntu-latest
+
+    env:
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
     steps:
       - name: Check actor permission
@@ -31,6 +39,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+          ref: ${{ env.RELEASE_TAG }}
           path: server
           fetch-depth: 0
 
@@ -64,7 +73,7 @@ jobs:
       # Since this action only runs on nextcloud-releases, ignoring is okay
       - name: Verify current tag # zizmor: ignore[template-injection]
         run: |
-         if [ "${{ github.ref_name }}" != "${{ env.CURRENT_TAG }}" ]; then
+         if [ "${{ env.RELEASE_TAG }}" != "${{ env.CURRENT_TAG }}" ]; then
            echo "Current tag does not match the release tag. Exiting."
            exit 1
          fi
@@ -89,20 +98,20 @@ jobs:
           composer install
 
       # Since this action only runs on nextcloud-releases, ignoring is okay
-      - name: Generate forum changelog between ${{ env.PREVIOUS_TAG }} and ${{ github.ref_name }} # zizmor: ignore[template-injection]
+      - name: Generate forum changelog between ${{ env.PREVIOUS_TAG }} and ${{ env.RELEASE_TAG }} # zizmor: ignore[template-injection]
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd github_helper/changelog
-          php index.php generate:changelog --no-bots --format=forum server ${{ env.PREVIOUS_TAG }} ${{ github.ref_name }} > changelog.md
+          php index.php generate:changelog --no-bots --format=forum server ${{ env.PREVIOUS_TAG }} ${{ env.RELEASE_TAG }} > changelog.md
 
       # Since this action only runs on nextcloud-releases, ignoring is okay
-      - name: Generate HTML changelog between ${{ env.PREVIOUS_TAG }} and ${{ github.ref_name }} # zizmor: ignore[template-injection]
+      - name: Generate HTML changelog between ${{ env.PREVIOUS_TAG }} and ${{ env.RELEASE_TAG }} # zizmor: ignore[template-injection]
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd github_helper/changelog
-          php index.php generate:changelog --no-bots --format=html server ${{ env.PREVIOUS_TAG }} ${{ github.ref_name }} > "${{ github.ref_name }}.html"
+          php index.php generate:changelog --no-bots --format=html server ${{ env.PREVIOUS_TAG }} ${{ env.RELEASE_TAG }} > "${{ env.RELEASE_TAG }}.html"
 
       # Since this action only runs on nextcloud-releases, ignoring is okay
       - name: Set changelog to release # zizmor: ignore[template-injection]
@@ -110,7 +119,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
          cd server
-         gh release edit ${{ github.ref_name }} --notes-file "../github_helper/changelog/changelog.md" --title "${{ github.ref_name }}"
+         gh release edit ${{ env.RELEASE_TAG }} --notes-file "../github_helper/changelog/changelog.md" --title "${{ env.RELEASE_TAG }}"
 
       # Since this action only runs on nextcloud-releases, ignoring is okay
       - name: Attach HTML changelog to release # zizmor: ignore[template-injection]
@@ -118,4 +127,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
          cd server
-         gh release upload ${{ github.ref_name }} "../github_helper/changelog/${{ github.ref_name }}.html" --clobber
+         gh release upload ${{ env.RELEASE_TAG }} "../github_helper/changelog/${{ env.RELEASE_TAG }}.html" --clobber


### PR DESCRIPTION
## Summary

- Moves the changelog generation workflow from `nextcloud/server` to this repo
- The `on: release` event only triggers workflows from the **default branch** (`main`) — the workflow on `master` (synced from server) never fired
- Generates both forum (release body) and HTML (release asset) changelogs
- HTML changelog is for the marketing team, attached to each release

Companion PR: nextcloud/server#60829 (removes the workflow from server)

## What the workflow does

1. Checks out `nextcloud/github_helper` and this repo (with full tag history)
2. Determines previous tag from git history (handles stable, RC, beta)
3. Generates forum changelog → sets as release body
4. Generates HTML changelog → attaches as release asset