### PR TITLE
perf: replace full server clone with API-based tag detection

### DIFF
--- a/.github/workflows/generate-release-changelog.yml
+++ b/.github/workflows/generate-release-changelog.yml
@@ -35,48 +35,44 @@ jobs:
           repository: nextcloud/github_helper
           path: github_helper
 
-      - name: Checkout server
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-          ref: ${{ env.RELEASE_TAG }}
-          path: server
-          fetch-depth: 0
-
       - name: Get previous tag
-        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cd server
-          # Print all tags
-          git log --decorate --oneline | egrep 'tag: ' | sed -r 's/^.+tag: ([^,\)]+)[,\)].+$/\1/g'
-          # Get the current tag
-          TAGS=$(git log --decorate --oneline | egrep 'tag: ' | sed -r 's/^.+tag: ([^,\)]+)[,\)].+$/\1/g')
-          CURRENT_TAG=$(echo "$TAGS" | head -n 1)
+          CURRENT_TAG="${{ env.RELEASE_TAG }}"
+          echo "Current tag: $CURRENT_TAG"
+
+          # Fetch all version tags via API instead of cloning the full repo
+          ALL_TAGS=$(gh api "repos/${{ github.repository }}/git/refs/tags" \
+            --paginate --jq '.[].ref | sub("refs/tags/"; "")' | \
+            grep -E '^v[0-9]' | sort -V)
+
+          # Verify the tag exists
+          if ! echo "$ALL_TAGS" | grep -qx "$CURRENT_TAG"; then
+            echo "::error::Tag $CURRENT_TAG not found in repository"
+            exit 1
+          fi
 
           # If current tag is the first beta, we use the previous major RC1
           if echo "$CURRENT_TAG" | grep -q 'beta1'; then
             MAJOR=$(echo "$CURRENT_TAG" | sed -E 's/^v([0-9]+).*/\1/')
             PREV=$((MAJOR - 1))
             PREVIOUS_TAG="v${PREV}.0.0rc1"
-          # Get the previous tag - filter pre-releases only if current tag is stable
+          # Pre-release: previous tag is the one right before in version order
           elif echo "$CURRENT_TAG" | grep -q 'rc\|beta\|alpha'; then
-            # Current tag is pre-release, don't filter
-            PREVIOUS_TAG=$(echo "$TAGS" | sed -n '2p')
+            PREVIOUS_TAG=$(echo "$ALL_TAGS" | grep -B1 "^${CURRENT_TAG}$" | head -1)
+          # Stable: previous stable tag (skip pre-releases)
           else
-            # Current tag is stable, filter out pre-releases
-            PREVIOUS_TAG=$(echo "$TAGS" | grep -v 'rc\|beta\|alpha' | sed -n '2p')
+            PREVIOUS_TAG=$(echo "$ALL_TAGS" | grep -v 'rc\|beta\|alpha' | grep -B1 "^${CURRENT_TAG}$" | head -1)
           fi
 
-          echo "CURRENT_TAG=$CURRENT_TAG" >> $GITHUB_ENV
-          echo "PREVIOUS_TAG=$PREVIOUS_TAG" >> $GITHUB_ENV
+          if [ -z "$PREVIOUS_TAG" ] || [ "$PREVIOUS_TAG" = "$CURRENT_TAG" ]; then
+            echo "::error::Could not determine previous tag for $CURRENT_TAG"
+            exit 1
+          fi
 
-      # Since this action only runs on nextcloud-releases, ignoring is okay
-      - name: Verify current tag # zizmor: ignore[template-injection]
-        run: |
-         if [ "${{ env.RELEASE_TAG }}" != "${{ env.CURRENT_TAG }}" ]; then
-           echo "Current tag does not match the release tag. Exiting."
-           exit 1
-         fi
+          echo "Previous tag: $PREVIOUS_TAG"
+          echo "PREVIOUS_TAG=$PREVIOUS_TAG" >> $GITHUB_ENV
 
       - name: Set up php 8.2
         uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
@@ -118,16 +114,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-         cd server
-         gh release edit ${{ env.RELEASE_TAG }} --notes-file "../github_helper/changelog/changelog-${{ env.RELEASE_TAG }}.md" --title "${{ env.RELEASE_TAG }}"
+         gh release edit ${{ env.RELEASE_TAG }} \
+           --repo "${{ github.repository }}" \
+           --notes-file "github_helper/changelog/changelog-${{ env.RELEASE_TAG }}.md" \
+           --title "${{ env.RELEASE_TAG }}"
 
       # Since this action only runs on nextcloud-releases, ignoring is okay
       - name: Attach changelog files to release # zizmor: ignore[template-injection]
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-         cd server
          gh release upload ${{ env.RELEASE_TAG }} \
-           "../github_helper/changelog/changelog-${{ env.RELEASE_TAG }}.md" \
-           "../github_helper/changelog/changelog-${{ env.RELEASE_TAG }}.html" \
+           "github_helper/changelog/changelog-${{ env.RELEASE_TAG }}.md" \
+           "github_helper/changelog/changelog-${{ env.RELEASE_TAG }}.html" \
+           --repo "${{ github.repository }}" \
            --clobber


### PR DESCRIPTION
## Summary

- Remove the `fetch-depth: 0` checkout of nextcloud/server (full clone of a massive repo)
- Fetch tags via GitHub API instead (`git/refs/tags` endpoint + `sort -V`)
- Use `gh release edit/upload --repo` instead of running from a local checkout
- Same previous-tag logic preserved (beta1, pre-release, stable filtering)

This eliminates the slowest step in the workflow — cloning the entire server history just to walk tags.