### PR TITLE
fix: don't fail tagger on individual repo errors

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -118,10 +118,10 @@ jobs:
             # Try stable branch first. If it doesn't exist (e.g. some repos
             # use "main" instead of "master"), fall back to the repo's default branch.
             REPO_BRANCH="$BRANCH"
-            SHA=$(gh api "repos/$repo/git/ref/heads/$REPO_BRANCH" --jq '.object.sha' 2>/dev/null)
+            SHA=$(gh api "repos/$repo/git/ref/heads/$REPO_BRANCH" --jq '.object.sha' 2>/dev/null || true)
             if [ -z "$SHA" ]; then
-              REPO_BRANCH=$(gh api "repos/$repo" --jq '.default_branch' 2>/dev/null)
-              SHA=$(gh api "repos/$repo/git/ref/heads/$REPO_BRANCH" --jq '.object.sha' 2>/dev/null)
+              REPO_BRANCH=$(gh api "repos/$repo" --jq '.default_branch' 2>/dev/null || true)
+              SHA=$(gh api "repos/$repo/git/ref/heads/$REPO_BRANCH" --jq '.object.sha' 2>/dev/null || true)
             fi
             echo -n "$repo@$REPO_BRANCH → $TAG ... "
 
@@ -133,7 +133,7 @@ jobs:
             fi
 
             # Check if tag already exists
-            EXISTING=$(gh api "repos/$repo/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null)
+            EXISTING=$(gh api "repos/$repo/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null || true)
             if [ -n "$EXISTING" ]; then
               if [ "${{ inputs.force }}" = "true" ]; then
                 echo -n "FORCE replacing ${EXISTING:0:8} ... "


### PR DESCRIPTION
## Summary

gh api calls inside command substitution crash the script under bash -e even with 2>/dev/null redirects. This caused the tagger to abort on the first repo that fails (e.g. token permissions), preventing all remaining repos from being tagged.

## Changes

- Add `|| true` to gh api calls in command substitutions so individual repo failures don't kill the loop
- Failures are still counted and reported in the step summary
- The workflow still exits non-zero if any repos failed to tag

## Test plan

- [ ] Trigger tagger with `v34.0.0rc4` — should process all repos even if one fails