### PR TITLE
refactor: extract tagger to standalone script with git fallback

### DIFF
--- a/.github/scripts/tag-repo.sh
+++ b/.github/scripts/tag-repo.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+#
+# Tag a single repository at a branch HEAD.
+# Uses gh release create+delete (fast), falls back to git clone+tag+push.
+#
+# Usage: tag-repo.sh <repo> <branch> <tag> [--force]
+#
+# Environment:
+#   GH_TOKEN          — GitHub token for gh CLI (required for gh mode)
+#   GIT_SSH_COMMAND   — optional SSH command for git fallback
+#
+# Exit codes: 0 = tagged or skipped, 1 = failed
+# Stdout: one of OK|SKIPPED|FAILED followed by details
+
+REPO="${1:?Usage: tag-repo.sh <repo> <branch> <tag> [--force]}"
+BRANCH="${2:?Missing branch}"
+TAG="${3:?Missing tag}"
+FORCE="${4:-}"
+
+# Server repos manage their own releases — never force-retag them
+SERVER_REPOS="nextcloud/server nextcloud-releases/server"
+
+# Check if gh CLI is available
+GH_AVAILABLE=false
+if command -v gh &>/dev/null; then
+  GH_AVAILABLE=true
+fi
+
+# Check if tag already exists (works with both gh and git)
+tag_exists_gh() {
+  gh api "repos/$REPO/git/ref/tags/$TAG" &>/dev/null
+}
+
+tag_exists_git() {
+  git ls-remote --tags "https://github.com/$REPO.git" "$TAG" 2>/dev/null | grep -q "$TAG"
+}
+
+# Check tag existence and handle skip/force logic
+# Returns: 0 = proceed with tagging, 1 = skip (already tagged), 2 = error
+check_existing_tag() {
+  local exists=false
+
+  if $GH_AVAILABLE; then
+    tag_exists_gh && exists=true
+  else
+    tag_exists_git && exists=true
+  fi
+
+  if ! $exists; then
+    return 0
+  fi
+
+  # Tag exists — check if this is a server repo (never force)
+  for server_repo in $SERVER_REPOS; do
+    if [ "$REPO" = "$server_repo" ]; then
+      echo "SKIPPED already tagged (server repo, never force)"
+      return 1
+    fi
+  done
+
+  if [ "$FORCE" = "--force" ]; then
+    echo "tag exists, force-replacing" >&2
+    return 0
+  fi
+
+  echo "SKIPPED already tagged"
+  return 1
+}
+
+tag_via_gh() {
+  # Force: delete existing release + tag first
+  if [ "$FORCE" = "--force" ]; then
+    gh release delete "$TAG" --repo "$REPO" --yes &>/dev/null || true
+    gh api -X DELETE "repos/$REPO/git/refs/tags/$TAG" &>/dev/null || true
+  fi
+
+  # Create release (creates the tag on the target branch)
+  local output
+  if ! output=$(gh release create "$TAG" \
+    --repo "$REPO" \
+    --target "$BRANCH" \
+    --title "$TAG" \
+    --notes "" \
+    2>&1); then
+    echo "gh release create failed: $output" >&2
+    return 1
+  fi
+
+  # Give GitHub a moment to propagate
+  sleep 1
+
+  # Delete the release, keep the tag
+  gh release delete "$TAG" --repo "$REPO" --yes &>/dev/null || true
+
+  echo "OK tagged via gh"
+  return 0
+}
+
+tag_via_git() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' EXIT
+
+  if ! git clone --depth 1 --branch "$BRANCH" "https://github.com/$REPO.git" "$tmpdir/repo" -q 2>/dev/null; then
+    # Try SSH if HTTPS fails
+    if ! git clone --depth 1 --branch "$BRANCH" "git@github.com:$REPO.git" "$tmpdir/repo" -q 2>/dev/null; then
+      echo "FAILED clone failed"
+      return 1
+    fi
+  fi
+
+  cd "$tmpdir/repo" || return 1
+
+  # Force: delete existing tag on remote
+  if [ "$FORCE" = "--force" ]; then
+    git push origin ":refs/tags/$TAG" 2>/dev/null || true
+  fi
+
+  git tag "$TAG"
+  if git push origin "$TAG" 2>/dev/null; then
+    echo "OK tagged via git"
+    return 0
+  else
+    echo "FAILED push failed"
+    return 1
+  fi
+}
+
+# Check if tag already exists
+check_existing_tag
+rc=$?
+if [ $rc -eq 1 ]; then
+  exit 0
+fi
+
+# Try gh first, fall back to git
+if $GH_AVAILABLE; then
+  if tag_via_gh; then
+    exit 0
+  fi
+  echo "gh failed, falling back to git clone" >&2
+fi
+
+if tag_via_git; then
+  exit 0
+fi
+
+echo "FAILED"
+exit 1

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -90,16 +90,18 @@ jobs:
           TAG="${{ env.RELEASE_TAG }}"
           BRANCH="${{ steps.config.outputs.branch }}"
           CONFIG="${{ steps.config.outputs.config }}"
+          FORCE_FLAG=""
+          if [ "${{ inputs.force }}" = "true" ]; then
+            FORCE_FLAG="--force"
+          fi
 
           # Merge app repos from build config + non-build repos from tag-only.json
-          # (server, 3rdparty, updater, example-files, documentation)
           REPOS=$(jq -r '.[].repo' "$CONFIG")
           if [ -f "tag-only.json" ]; then
             REPOS=$(echo "$REPOS"; jq -r '.[]' "tag-only.json")
           fi
           REPOS=$(echo "$REPOS" | sort -u)
 
-          TOTAL=0
           SUCCESS=0
           SKIPPED=0
           FAILED=0
@@ -107,65 +109,44 @@ jobs:
           {
             echo "## Tag results: $TAG"
             echo ""
-            echo "| Repository | Branch | Status | Commit |"
-            echo "|---|---|---|---|"
+            echo "| Repository | Branch | Status |"
+            echo "|---|---|---|"
           } >> "$GITHUB_STEP_SUMMARY"
 
           while read -r repo; do
             [ -z "$repo" ] && continue
-            TOTAL=$((TOTAL + 1))
 
-            # Try stable branch first. If it doesn't exist (e.g. some repos
-            # use "main" instead of "master"), fall back to the repo's default branch.
+            # Resolve branch: try stable branch, fall back to repo default
             REPO_BRANCH="$BRANCH"
-            SHA=$(gh api "repos/$repo/git/ref/heads/$REPO_BRANCH" --jq '.object.sha' 2>/dev/null || true)
-            if [ -z "$SHA" ]; then
-              REPO_BRANCH=$(gh api "repos/$repo" --jq '.default_branch' 2>/dev/null || true)
-              SHA=$(gh api "repos/$repo/git/ref/heads/$REPO_BRANCH" --jq '.object.sha' 2>/dev/null || true)
+            if ! gh api "repos/$repo/git/ref/heads/$REPO_BRANCH" &>/dev/null; then
+              REPO_BRANCH=$(gh api "repos/$repo" --jq '.default_branch' 2>/dev/null) || REPO_BRANCH=""
             fi
-            echo -n "$repo@$REPO_BRANCH → $TAG ... "
 
-            if [ -z "$SHA" ]; then
-              echo "SKIP (no branch found)"
-              echo "| \`$repo\` | - | no branch found | - |" >> "$GITHUB_STEP_SUMMARY"
+            if [ -z "$REPO_BRANCH" ]; then
+              echo "$repo: no branch found"
+              echo "| \`$repo\` | - | no branch found |" >> "$GITHUB_STEP_SUMMARY"
               FAILED=$((FAILED + 1))
               continue
             fi
 
-            # Check if tag already exists
-            EXISTING=$(gh api "repos/$repo/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null || true)
-            if [ -n "$EXISTING" ]; then
-              if [ "${{ inputs.force }}" = "true" ]; then
-                echo -n "FORCE replacing ${EXISTING:0:8} ... "
-                gh release delete "$TAG" --repo "$repo" --yes 2>/dev/null || true
-                gh api -X DELETE "repos/$repo/git/refs/tags/$TAG" 2>/dev/null || true
-              else
-                echo "EXISTS (${EXISTING:0:8})"
-                echo "| \`$repo\` | $REPO_BRANCH | already tagged | \`${EXISTING:0:8}\` |" >> "$GITHUB_STEP_SUMMARY"
-                SKIPPED=$((SKIPPED + 1))
-                continue
-              fi
-            fi
+            echo -n "$repo@$REPO_BRANCH → $TAG ... "
+            RESULT=$(bash .github/scripts/tag-repo.sh "$repo" "$REPO_BRANCH" "$TAG" $FORCE_FLAG)
+            echo "$RESULT"
 
-            # Create tag via temporary release. gh release create makes a tag
-            # on the target branch. We then delete the release but the tag stays.
-            # This avoids needing git clone + SSH keys for each repo.
-            if gh release create "$TAG" \
-              --repo "$repo" \
-              --target "$REPO_BRANCH" \
-              --title "$TAG" \
-              --notes "" \
-              > /dev/null 2>&1; then
-              # Delete the release, keep the tag
-              gh release delete "$TAG" --repo "$repo" --yes 2>/dev/null || true
-              echo "OK (${SHA:0:8})"
-              echo "| \`$repo\` | $REPO_BRANCH | tagged | \`${SHA:0:8}\` |" >> "$GITHUB_STEP_SUMMARY"
-              SUCCESS=$((SUCCESS + 1))
-            else
-              echo "FAILED"
-              echo "| \`$repo\` | $REPO_BRANCH | **failed** | - |" >> "$GITHUB_STEP_SUMMARY"
-              FAILED=$((FAILED + 1))
-            fi
+            case "$RESULT" in
+              OK*)
+                echo "| \`$repo\` | $REPO_BRANCH | tagged |" >> "$GITHUB_STEP_SUMMARY"
+                SUCCESS=$((SUCCESS + 1))
+                ;;
+              SKIPPED*)
+                echo "| \`$repo\` | $REPO_BRANCH | already tagged |" >> "$GITHUB_STEP_SUMMARY"
+                SKIPPED=$((SKIPPED + 1))
+                ;;
+              *)
+                echo "| \`$repo\` | $REPO_BRANCH | **failed** |" >> "$GITHUB_STEP_SUMMARY"
+                FAILED=$((FAILED + 1))
+                ;;
+            esac
           done <<< "$REPOS"
 
           {


### PR DESCRIPTION
## Summary

Extract the tagging logic from `release-tag.yml` into a standalone `tag-repo.sh` script.

**Primary**: `gh release create` + `delete` to tag without cloning (fast).
**Fallback**: `git clone` + `tag` + `push` when `gh` CLI is unavailable.

Fixes the broken tag existence check — `gh api --jq` returns the JSON error body on 404 (not empty string), causing every repo to show "EXISTS". Uses `gh release view` instead.

## Test plan

- [ ] Trigger tagger with `v34.0.0rc4 --force` to re-tag all repos
- [ ] Check step summary shows all repos processed
- [ ] Verify tags exist: `gh api repos/nextcloud/activity/git/ref/tags/v34.0.0rc4`