### PR TITLE
feat: trigger release pipeline via workflow_dispatch

### DIFF
--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
 
-name: Generate changelog on release
+name: Generate release changelog
 run-name: "Changelog ${{ inputs.tag }}"
 
 on:

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -2,10 +2,14 @@
 # SPDX-License-Identifier: MIT
 
 name: Generate changelog on release
+run-name: "Changelog ${{ inputs.tag }}"
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,23 +2,34 @@
 # SPDX-License-Identifier: MIT
 
 name: Release pipeline
-run-name: "Release ${{ github.ref_name }}"
+run-name: "Release ${{ inputs.tag }}"
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v34.0.1)'
+        required: true
 
 jobs:
   tag:
-    if: startsWith(github.ref_name, 'v')
+    if: startsWith(inputs.tag, 'v')
     uses: ./.github/workflows/release-tag.yml
     with:
-      tag: ${{ github.ref_name }}
+      tag: ${{ inputs.tag }}
+    secrets: inherit
+
+  changelog:
+    if: startsWith(inputs.tag, 'v')
+    uses: ./.github/workflows/release-changelog.yml
+    with:
+      tag: ${{ inputs.tag }}
     secrets: inherit
 
   build:
-    if: startsWith(github.ref_name, 'v')
+    if: startsWith(inputs.tag, 'v')
+    needs: [tag, changelog]
     uses: ./.github/workflows/release-build.yml
     with:
-      tag: ${{ github.ref_name }}
+      tag: ${{ inputs.tag }}
     secrets: inherit


### PR DESCRIPTION
## Summary

- Switch release pipeline trigger from `on: release: published` to `workflow_dispatch`, so the workflow runs from `main` instead of the tag ref (where it doesn't exist)
- Restructure pipeline: tag repos + generate changelog run in parallel, build waits for both to complete
- Rename `generate-release-changelog.yml` to `release-changelog.yml` for naming consistency
- Add `workflow_call` support + `run-name` to changelog workflow

The release script will trigger the pipeline after publishing:
```bash
gh workflow run release.yml --repo nextcloud-releases/server --ref main -f tag="v$VERSION"
```

## Pipeline flow

```
release.sh → publish + upload → gh workflow run (on main)
                                       │
                              ┌────────┴────────┐
                              │                  │
                          tag repos         changelog
                              │                  │
                              └────────┬────────┘
                                       │
                                  build release
```

## Test plan

- [ ] Manually trigger `release.yml` via `gh workflow run` with a test tag
- [ ] Verify tag + changelog jobs run in parallel
- [ ] Verify build job waits for both to complete
- [ ] Verify `release-changelog.yml` still works standalone via `workflow_dispatch`