### PR TITLE
fix: changelog must wait for tagging + drop sourcemap .license sidecars

### DIFF
--- a/.github/scripts/clean-dev-files.sh
+++ b/.github/scripts/clean-dev-files.sh
@@ -88,3 +88,8 @@ for base in "${JS_CONFIG_BASES[@]}"; do
   done
 done
 
+# Remove REUSE sidecar files for sourcemaps. Sourcemaps (*.map) ship in the
+# release, but their *.map.license sidecars are REUSE metadata that only matters
+# in source repos — pure clutter in the tarball.
+find . -type f -name '*.map.license' -delete
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
     secrets: inherit
 
   changelog:
+    needs: tag
     if: startsWith(inputs.tag, 'v')
     uses: ./.github/workflows/release-changelog.yml
     with:
@@ -27,8 +28,8 @@ jobs:
     secrets: inherit
 
   build:
-    if: startsWith(inputs.tag, 'v')
     needs: [tag, changelog]
+    if: startsWith(inputs.tag, 'v')
     uses: ./.github/workflows/release-build.yml
     with:
       tag: ${{ inputs.tag }}


### PR DESCRIPTION
## Summary

Fixes a remaining ordering gap in the release pipeline and removes sourcemap license clutter from the tarball.

### Pipeline ordering

After #80 the pipeline is `workflow_dispatch` driven and looks like:

- `changelog` ran in parallel with `tag`
- `build` ran with `needs: [tag, changelog]`

But the **changelog generator resolves cross-repo tags**, so running it in parallel with `tag` still races: tags it depends on may not exist yet. This adds `needs: tag` to the `changelog` job:

```
tag ──► changelog ──► build
        (needs: tag)  (needs: [tag, changelog])
```

### Sourcemap `.license` cleanup

`*.map.license` REUSE sidecars are source-repo metadata and pure clutter in the release tarball. `clean-dev-files.sh` now strips them, while keeping:

- the `*.map` sourcemaps themselves
- the source file `*.js.license` / `*.css.license` headers

## Testing

- Run the release pipeline and confirm `changelog` starts only after `tag` succeeds, and `build` after both.
- Inspect a built tarball: no `*.map.license` files, but `*.map` and `*.js.license`/`*.css.license` are present.
- Manual changelog regen via `release-changelog.yml` → Run workflow still works.
