### PR TITLE
fix: strip *.map.license sidecars from server root

### DIFF
--- a/.github/scripts/clean-server-dev-files.sh
+++ b/.github/scripts/clean-server-dev-files.sh
@@ -39,5 +39,9 @@ else
   rm -rf .direnv .well-known config/config.php data
 fi
 
+# Strip REUSE sidecar files for sourcemaps. *.map files ship in the release,
+# but *.map.license sidecars are source-repo metadata — clutter in the tarball.
+find . -type f -name '*.map.license' -delete
+
 # Remove .git last (needed above for git ls-files)
 rm -rf .git


### PR DESCRIPTION
## Summary

`clean-dev-files.sh` (called per app dir + core/settings) already strips `*.map.license` sidecars. But `clean-server-dev-files.sh` — which runs on the server repository root at fetch time — did not. Server `dist/*.map.license` files survived into the release tarball.

Adds the same `find . -type f -name '*.map.license' -delete` to `clean-server-dev-files.sh`, placed before `rm -rf .git` so it runs on the full working tree.

Keeps `*.map` sourcemaps and source file `*.js.license`/`*.css.license` headers intact.

## Testing

Inspect a built tarball: no `*.map.license` files present anywhere (server root or apps), but `*.map` and `*.js.license`/`*.css.license` remain.