### PR TITLE
fix: mark *.map.license as known diff in compare

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -520,7 +520,8 @@ jobs:
           # - .chunk.(mjs|css): hash-based filenames change with any code diff
           # - *.config.*: workflow strips dev configs the release script kept
           # - l10n: translation files may update between builds
-          KNOWN_PATTERN='(signature\.json|core/doc/|Nextcloud Manual\.pdf|\.chunk\.(mjs|css)|\.config\.(js|ts|mjs|cjs)$|\.prettierignore|/l10n/[^/]*\.(js|json)$)'
+          # - *.map.license: workflow strips REUSE sourcemap sidecars; official release keeps them
+          KNOWN_PATTERN='(signature\.json|core/doc/|Nextcloud Manual\.pdf|\.chunk\.(mjs|css)|\.config\.(js|ts|mjs|cjs)$|\.prettierignore|/l10n/[^/]*\.(js|json)$|\.map\.license$)'
           UNEXPECTED_MISSING=$(grep -v -E "$KNOWN_PATTERN" /tmp/only-in-existing.txt | wc -l)
           UNEXPECTED_EXTRA=$(grep -v -E "$KNOWN_PATTERN" /tmp/only-in-new.txt | wc -l)
 


### PR DESCRIPTION
## Summary

The workflow strips `*.map.license` REUSE sidecars from the built release; the official release script keeps them. This causes the compare job to flag them as unexpected differences on every run.

Add `\.map\.license$` to `KNOWN_PATTERN` so these are treated as an acceptable/expected divergence between our workflow build and the official release.

The `*.map.license` files appeared under "Only in release script build" — confirming our cleanup works and these are intentionally absent from the workflow output.