### PR TITLE
ci: pin codecov-action + always-run updater-script tests

### DIFF
--- a/.github/workflows/test-release-tools.yml
+++ b/.github/workflows/test-release-tools.yml
@@ -42,7 +42,7 @@ jobs:
         run: vendor/bin/phpunit --testsuite ${{ matrix.suite }} --coverage-text --coverage-clover coverage.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           files: tools/release/coverage.xml
           flags: ${{ matrix.suite }}

--- a/.github/workflows/test-updater-script.yml
+++ b/.github/workflows/test-updater-script.yml
@@ -7,13 +7,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - '.github/scripts/update-updater-server.sh'
-      - 'tests/updater-script/**'
   pull_request:
-    paths:
-      - '.github/scripts/update-updater-server.sh'
-      - 'tests/updater-script/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
Two small CI follow-ups:

- Pin `codecov/codecov-action` to a commit SHA (`0fb7174` # v5) in `test-release-tools.yml`, matching the repo's SHA-pinning convention for actions.
- Drop the `paths:` filter from `test-updater-script.yml` so it runs on every push to `main` and every PR, not only when those files change.

(`test-build-scripts.yml` is not on main, and `test-milestone-scripts.yml` was removed with the PHP migration, so no change needed there.)