### PR TITLE
fix(release-tools): don't re-close an already-closed milestone

### DIFF
--- a/tools/release/src/MilestoneUpdater.php
+++ b/tools/release/src/MilestoneUpdater.php
@@ -150,6 +150,11 @@ final class MilestoneUpdater
 
     private function close(string $repo, Milestone $current): void
     {
+        // Already closed (e.g. re-running a shipped release to fix due dates):
+        // nothing to do. Don't call the API, count it, or claim we closed it.
+        if ($current->state === 'closed') {
+            return;
+        }
         $this->closed++;
         if ($this->dryRun) {
             $this->log[] = "  {$repo}: would close '{$current->title}'";

--- a/tools/release/tests/MilestoneUpdaterTest.php
+++ b/tools/release/tests/MilestoneUpdaterTest.php
@@ -203,4 +203,22 @@ final class MilestoneUpdaterTest extends TestCase
         $this->assertNotEmpty($u->log);
         $this->assertStringContainsString('would', strtolower(implode("\n", $u->log)));
     }
+
+    public function testAlreadyClosedCurrentIsNotReclosed(): void
+    {
+        // Re-running a shipped release (e.g. to backfill due dates): the current
+        // milestone is already closed, so it must not be closed again, counted,
+        // or logged as closed.
+        $api = new FakeGitHubApi();
+        $api->seedMilestone(self::REPO, 10, 'Nextcloud 33.0.4', 'closed');
+        $api->seedMilestone(self::REPO, 11, 'Nextcloud 33.0.5');
+        $api->seedMilestone(self::REPO, 12, 'Nextcloud 33.0.6');
+
+        $u = new MilestoneUpdater($api);
+        $u->run(Version::fromTag('v33.0.4'), [self::REPO]);
+
+        $this->assertSame([], $api->journal, 'nothing to do: no re-close, no moves, milestones already exist');
+        $this->assertSame(0, $u->closed);
+        $this->assertStringNotContainsString('closed', strtolower(implode("\n", $u->log)));
+    }
 }


### PR DESCRIPTION
## What

`milestones:update` skips the close step when the release's current milestone is already closed.

## Why

Re-running a shipped release to backfill due dates on the next patch milestones (as just done for v32.0.11 / v33.0.5) still issued a `close` per repo, counted it (`closed=27`), and logged `closed 'Nextcloud 32.0.11'` even though those milestones were already closed. Misleading, and 27 redundant API calls per run.

Now: if `current.state === 'closed'`, close is a no-op (no API call, no count, no log line). For a normal release the milestone is open and closes as before.

## Testing

`composer test` -> 109 tests. New `testAlreadyClosedCurrentIsNotReclosed`: a closed current milestone yields an empty journal, `closed=0`, and no "closed" log line.