### PR TITLE
ci(release-updater): allow dry-run before the release exists (fake signatures)

### DIFF
--- a/.github/workflows/release-updater.yml
+++ b/.github/workflows/release-updater.yml
@@ -74,6 +74,17 @@ jobs:
           VERSION="${{ steps.parse.outputs.version }}"
           mkdir -p /tmp/release
 
+          # A dry run only renders the diff; the release (and its .sig files) may
+          # not exist yet. Use a fake but well-formed signature so the bump and
+          # `make config/config.php` succeed without touching the release.
+          if [ "${{ inputs.dry_run || 'false' }}" = "true" ]; then
+            FAKE=$(printf 'A%.0s' {1..342})==
+            echo "bz2=${FAKE}" >> "$GITHUB_OUTPUT"
+            echo "zip=${FAKE}" >> "$GITHUB_OUTPUT"
+            echo "::notice::dry run - using fake signatures, skipping release download"
+            exit 0
+          fi
+
           # Download .sig files attached to the GitHub release
           for ext in tar.bz2 zip; do
             sigfile="nextcloud-${VERSION}.${ext}.sig"


### PR DESCRIPTION
## What & why

The \`release-updater\` workflow has a \`dry_run\` input that renders the updater-server diff without opening a PR. But it was unusable for the main case you'd want a preview — **a release that isn't built yet** — because the *Download signatures* step hard-fails when the release (or its \`.sig\` files) doesn't exist:

> ::error::Signature file nextcloud-34.0.2rc1.tar.bz2.sig not found on release v34.0.2rc1

(see run [28431788530](https://github.com/nextcloud-releases/server/actions/runs/28431788530/job/84247994610)).

## Change

On a dry run, skip the release download and feed the bump a **fake but well-formed** 344-char signature. The signature only needs to be consistent between \`releases.json\` and the generated feature files (which the tool guarantees), so \`updater:bump\` + \`make config/config.php\` run and the diff renders without any real release.

Non-dry runs are unchanged — real signatures are still fetched and the step still fails if they're missing.

\`\`\`bash
if [ "${{ inputs.dry_run || 'false' }}" = "true" ]; then
  FAKE=$(printf 'A%.0s' {1..342})==
  echo "bz2=${FAKE}" >> "$GITHUB_OUTPUT"
  echo "zip=${FAKE}" >> "$GITHUB_OUTPUT"
  echo "::notice::dry run - using fake signatures, skipping release download"
  exit 0
fi
\`\`\`

## Testing

- `gh workflow run release-updater.yml -f tag=v34.0.2rc1 -f dry_run=true` — previously failed at signature download; now reaches the bump + `make config/config.php` and prints the full diff.
- Non-dry run path untouched.

> Note: the internal-version / minPHP fetch already falls back to the `stable{major}` branch, so it doesn't block a dry run of an unbuilt tag.