### PR TITLE
enh: package dbdoctor in stable35 and master builds

### DIFF
--- a/master.json
+++ b/master.json
@@ -40,6 +40,11 @@
     "repo": "nextcloud/office"
   },
   {
+    "id": "dbdoctor",
+    "repo": "nextcloud/dbdoctor",
+    "composer_args": "--no-dev -a --quiet"
+  },
+  {
     "id": "password_policy",
     "repo": "nextcloud/password_policy"
   },

--- a/stable35.json
+++ b/stable35.json
@@ -40,6 +40,11 @@
     "repo": "nextcloud/office"
   },
   {
+    "id": "dbdoctor",
+    "repo": "nextcloud/dbdoctor",
+    "composer_args": "--no-dev -a --quiet"
+  },
+  {
     "id": "password_policy",
     "repo": "nextcloud/password_policy"
   },


### PR DESCRIPTION
## What

Add `dbdoctor` to `stable35.json` and `master.json` so the workflow build bundles it, matching the release-script build.
